### PR TITLE
New: Remove master branch restriction in favor of specifying by repo 💥

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const githubOpts = require('./lib/github-opts')
 const releaseNotesGeneratorOpts = require('./lib/release-notes-generator-opts')
 
 module.exports = {
-  branch: 'master',
   // Option is passed to all plugins to configure using ESLint commit format
   preset: 'eslint',
   plugins: [


### PR DESCRIPTION
BREAKING CHANGE: Semantic release is no longer restricted to master branch and should be specified
in each repo's CI/CD configurations